### PR TITLE
Wrong syntax in the example on usage page (doc mistake fixing).

### DIFF
--- a/docs/usage.rst
+++ b/docs/usage.rst
@@ -47,7 +47,7 @@ user's location should be accessible via ``request`` object::
     def my_view(request):
         """ Passing location into template """
         ...
-        context['location] = request.location
+        context['location'] = request.location
         ...
 
 ``request.location`` is an instance of a custom model that you're required to create on your own


### PR DESCRIPTION
context['location] should be context['location']
