### PR TITLE
Allow to use iprange queryset methods

### DIFF
--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -35,7 +35,11 @@ class IpRangeTest(TestCase):
         self.assertEqual(ip_range.city, self.city)
         self.assertEqual(ip_range.city.region, self.region)
         self.assertEqual(ip_range.city.region.country, self.country)
-
+        # with select_related
+        ip_range = IpRange.objects.select_related('city', 'region', 'country').by_ip('43.123.56.12')
+        self.assertEqual(ip_range.city, self.city)
+        self.assertEqual(ip_range.region, self.region)
+        self.assertEqual(ip_range.country, self.country)
 
 class GeoFacadeTest(TestCase):
 


### PR DESCRIPTION
Currently it is not possible to use standard queryset methods of `IpRange` model together with `by_ip` method.

Example:

```
>>> IpRange.objects.select_related('city', 'region', 'country').by_ip('43.123.56.12')
...
AttributeError: 'QuerySet' object has no attribute 'by_ip'
```

This patch tries to fix it.
