### PR TITLE
get_query_set was removed in Django 1.8

### DIFF
--- a/django_geoip/models.py
+++ b/django_geoip/models.py
@@ -94,14 +94,14 @@ class IpRangeManager(models.Manager):
     """
     Manager allows to apply and mix any queryset methods, including custom.
     """
-    def get_query_set(self):
+    def get_queryset(self):
         return IpRangeQuerySet(self.model)
 
     def __getattr__(self, attr, *args):
         # see https://code.djangoproject.com/ticket/15062 for details
         if attr.startswith("_"):
             raise AttributeError
-        return getattr(self.get_query_set(), attr, *args)
+        return getattr(self.get_queryset(), attr, *args)
 
 
 class IpRange(models.Model):


### PR DESCRIPTION
See release notes: https://docs.djangoproject.com/en/1.9/releases/1.8/#features-removed-in-1-8

I propose to bring the application into conformity with the Django 1.8 and release a new version on the pip.
