### PR TITLE
Make urlpatterns a normal Python list

### DIFF
--- a/django_geoip/urls.py
+++ b/django_geoip/urls.py
@@ -1,11 +1,11 @@
 # -*- coding: utf-8 -*-
 try:
-    from django.conf.urls import *
+    from django.conf.urls import url
 except ImportError:
-    from django.conf.urls.defaults import *
+    from django.conf.urls.defaults import url
 
 from django_geoip.views import set_location
 
-urlpatterns = patterns('',
+urlpatterns = [
     url(r'^setlocation/', set_location, name='geoip_change_location'),
-)
+]


### PR DESCRIPTION
According to the [docs](https://docs.djangoproject.com/en/1.9/ref/urls/#patterns), the `patterns` function is deprecated since Django 1.8.

This change is not compatible with Django versions < 1.8, but 1.8 is an LTS release so there's no real reason to stay on previous versions. If you would like me keep support for previous Django versions I can rework the PR.
