### PR TITLE
Compatibility fixes for Django from 1.4 to 1.9

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -33,3 +33,5 @@ nosetests.xml
 .mr.developer.cfg
 .project
 .pydevproject
+
+.idea

--- a/README.rst
+++ b/README.rst
@@ -12,6 +12,6 @@ App to figure out where your visitors are from by their IP address.
 Detects country, region and city, querying the database with geodata.
 Optional high-level API provides user location in request object.
 
-Requires Django 1.4+, supports python 2 & 3.
+Requires Django 1.4+, supports python 2.6, 2.7, 3.4, 3.5.
 
 Docs: http://django-geoip.readthedocs.org/

--- a/django_geoip/__init__.py
+++ b/django_geoip/__init__.py
@@ -1,1 +1,1 @@
-
+default_app_config = 'apps.GeoConfig'

--- a/django_geoip/__init__.py
+++ b/django_geoip/__init__.py
@@ -1,1 +1,1 @@
-default_app_config = 'apps.GeoConfig'
+default_app_config = 'apps.Config'

--- a/django_geoip/__init__.py
+++ b/django_geoip/__init__.py
@@ -1,1 +1,1 @@
-default_app_config = 'apps.GeoConfig'
+default_app_config = 'django_geoip.apps.Config'

--- a/django_geoip/__init__.py
+++ b/django_geoip/__init__.py
@@ -1,1 +1,1 @@
-default_app_config = 'apps.Config'
+default_app_config = 'django_geoip.apps.Config'

--- a/django_geoip/apps.py
+++ b/django_geoip/apps.py
@@ -1,0 +1,6 @@
+from django.apps import AppConfig
+
+
+class Config(AppConfig):
+    name = 'django_geoip'
+    verbose_name = "Django GeoIP"

--- a/django_geoip/models.py
+++ b/django_geoip/models.py
@@ -97,6 +97,11 @@ class IpRangeManager(models.Manager):
     def get_queryset(self):
         return IpRangeQuerySet(self.model)
 
+    def get_query_set(self):
+        """ backward compatibility with Django < 1.8
+        """
+        return self.get_queryset()
+
     def __getattr__(self, attr, *args):
         # see https://code.djangoproject.com/ticket/15062 for details
         if attr.startswith("_"):

--- a/django_geoip/views.py
+++ b/django_geoip/views.py
@@ -16,7 +16,7 @@ def set_location(request):
     redirect to the page in the request (the 'next' parameter) without changing
     any state.
     """
-    next = request.REQUEST.get('next', None)
+    next = request.GET.get('next', None) or request.POST.get('next', None)
     if not next:
         next = request.META.get('HTTP_REFERER', None)
     if not next:

--- a/setup.py
+++ b/setup.py
@@ -7,7 +7,7 @@ read = lambda filepath: codecs.open(filepath, 'r', 'utf-8').read()
 
 setup(
     name='django-geoip',
-    version='0.5.2',
+    version='0.5.2.1',
     author='Ilya Baryshev',
     author_email='baryshev@gmail.com',
     packages=find_packages(exclude=("tests", "test_app", "docs")),

--- a/test_app/test_settings.py
+++ b/test_app/test_settings.py
@@ -13,6 +13,7 @@ else:
 SECRET_KEY = '_'
 ROOT_URLCONF = 'test_app.urls'
 INSTALLED_APPS = ('django_geoip', 'test_app')
+MIDDLEWARE_CLASSES = ()
 
 if django.VERSION[:2] < (1, 6):
     TEST_RUNNER = 'discover_runner.DiscoverRunner'

--- a/tests/test_middleware.py
+++ b/tests/test_middleware.py
@@ -4,7 +4,6 @@ from mock import patch
 from django.conf import settings
 from django.test import TestCase
 from django.test.client import RequestFactory
-from django.utils import unittest
 from django.http import HttpResponse
 
 import django_geoip
@@ -66,8 +65,7 @@ class MiddlewareTest(TestCase):
         self.assertFalse(mock_set.called)
 
 
-@unittest.skipIf(RequestFactory is None, "RequestFactory is avaliable from 1.3")
-class GetLocationTest(unittest.TestCase):
+class GetLocationTest(TestCase):
     def setUp(self, *args, **kwargs):
         self.factory = RequestFactory()
 

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -51,6 +51,9 @@ class GeoFacadeTest(TestCase):
             def get_by_ip_range(cls, ip_range):
                 return None
 
+            class Meta:
+                app_label = 'tests'
+
         self.assertRaises(TypeError, MyFacade)
 
     def test_facade_is_abstract_django_model(self):

--- a/tox.ini
+++ b/tox.ini
@@ -1,9 +1,9 @@
 [tox]
 envlist = py{26,27,34}-django{15,16},
           py26-django14,
-          py27-django14,
-          py27-django17,
-          py34-django17,
+          py27-django{14,17,18,19},
+          py34-django{17,18,19},
+          py35-django{18,19},
           sphinx
 downloadcache = {toxworkdir}/_download/
 
@@ -18,11 +18,12 @@ deps =
     django15: Django>=1.5,<1.6
     django16: Django>=1.6,<1.7
     django17: Django>=1.7,<1.8
-
+    django18: Django>=1.8,<1.9
+    django19: Django>=1.9,<1.10
 
 [testenv:sphinx]
 deps =
-    Django>=1.4
+    Django>=1.8,<1.9
     Sphinx
 changedir = {toxinidir}/docs
 commands = sphinx-build -n -b html -d .build/doctrees . .build/html


### PR DESCRIPTION
Thers are fixes for support all django versions from 1.4 to 1.9, new tox tests for py35 and django 1.8, 1.9. It have been toxed properly.

```
  py26-django15: commands succeeded
  py26-django16: commands succeeded
  py27-django15: commands succeeded
  py27-django16: commands succeeded
  py34-django15: commands succeeded
  py34-django16: commands succeeded
  py26-django14: commands succeeded
  py27-django14: commands succeeded
  py27-django17: commands succeeded
  py27-django18: commands succeeded
  py27-django19: commands succeeded
  py34-django17: commands succeeded
  py34-django18: commands succeeded
  py34-django19: commands succeeded
  py35-django18: commands succeeded
  py35-django19: commands succeeded
  sphinx: commands succeeded
  congratulations :)

```
