### PR TITLE
django 1.10 support: urls, middleware, docs, tests

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -12,6 +12,6 @@ App to figure out where your visitors are from by their IP address.
 Detects country, region and city, querying the database with geodata.
 Optional high-level API provides user location in request object.
 
-Requires Django 1.4+, supports python 2.6, 2.7, 3.4, 3.5.
+Requires Django 1.10+, supports python 2.7, 3.4, 3.5.
 
 Docs: http://django-geoip.readthedocs.org/

--- a/django_geoip/middleware.py
+++ b/django_geoip/middleware.py
@@ -1,4 +1,5 @@
 # -*- coding: utf-8 -*-
+from django.utils.deprecation import MiddlewareMixin
 from django.utils.functional import SimpleLazyObject
 from django_geoip.base import storage_class
 
@@ -10,7 +11,7 @@ def get_location(request):
     return request._cached_location
 
 
-class LocationMiddleware(object):
+class LocationMiddleware(MiddlewareMixin):
 
     def process_request(self, request):
         """ Don't detect location, until we request it implicitly """

--- a/docs/installation.rst
+++ b/docs/installation.rst
@@ -1,7 +1,7 @@
 Installation
 ============
 
-This app works with python 2.6-2.7, 3.2-3.3, Django 1.3 and higher.
+This app works with python 2.7, 3.4+, Django 1.10 and higher.
 
 Recommended way to install is via pip::
 
@@ -22,10 +22,6 @@ Basic
 
 * Create application tables in database::
 
-    python manage.py syncdb
-
-  If you're using South::
-
     python manage.py migrate
 
 
@@ -43,7 +39,7 @@ In order to make :ref:`user's location detection automatic <highlevel>` several 
 
 * Add ``LocationMiddleware`` to ``MIDDLEWARE_CLASSES``::
 
-    MIDDLEWARE_CLASSES = (...
+    MIDDLEWARE = (...
         'django_geoip.middleware.LocationMiddleware',
         ...
     )
@@ -56,11 +52,11 @@ In order to make :ref:`user's location detection automatic <highlevel>` several 
 
 * Include app urls into your urlconf if you want to :ref:`allow visitors to change their location <setlocation>`::
 
-    urlpatterns += patterns('',
+    urlpatterns += [
         ...
-        (r'^geoip/', include('django_geoip.urls')),
+        url(r'^geoip/', include('django_geoip.urls')),
         ...
-    )
+    ]
 
 * Add local ISO codes if you want to change or add countries in :ref:`settings`::
 

--- a/test_app/test_settings.py
+++ b/test_app/test_settings.py
@@ -13,7 +13,9 @@ else:
 SECRET_KEY = '_'
 ROOT_URLCONF = 'test_app.urls'
 INSTALLED_APPS = ('django_geoip', 'test_app')
-MIDDLEWARE_CLASSES = ()
+MIDDLEWARE = [
+
+]
 
 GEOIP_CUSTOM_ISO_CODES = {"RU": "Russian Federation Custom Name"}
 

--- a/test_app/urls.py
+++ b/test_app/urls.py
@@ -1,8 +1,5 @@
 # coding: utf-8
-try:
-    from django.conf.urls import patterns, include
-except ImportError:
-    from django.conf.urls.defaults import patterns, include
+from django.conf.urls import url, include
 from django.http import HttpResponse
 from django_geoip.views import set_location
 
@@ -11,8 +8,8 @@ def index_view(request):
     return HttpResponse()
 
 
-urlpatterns = patterns('',
-    ('^$', index_view),
-    (r'^geoip/', include('django_geoip.urls')),
-    ('^hello/$', index_view),
-)
+urlpatterns = [
+    url('^$', index_view),
+    url(r'^geoip/', include('django_geoip.urls')),
+    url('^hello/$', index_view),
+]

--- a/tox.ini
+++ b/tox.ini
@@ -1,9 +1,8 @@
 [tox]
-envlist = py{26,27,34}-django{15,16},
-          py26-django14,
-          py27-django{14,17,18,19},
-          py34-django{17,18,19},
-          py35-django{18,19},
+envlist =
+          py27-django{110},
+          py34-django{110},
+          py35-django{110},
           sphinx
 downloadcache = {toxworkdir}/_download/
 
@@ -14,12 +13,7 @@ commands =
     python manage.py test --traceback
 deps =
     -r{toxinidir}/tests/requirements.txt
-    django14: Django>=1.4,<1.5
-    django15: Django>=1.5,<1.6
-    django16: Django>=1.6,<1.7
-    django17: Django>=1.7,<1.8
-    django18: Django>=1.8,<1.9
-    django19: Django>=1.9,<1.10
+    django110: Django>=1.10,<1.11
 
 [testenv:sphinx]
 deps =


### PR DESCRIPTION
There are more fixes for django 1.10. Also I drop support of python 2.6 and django < 1.10. I think, if somebody would not like to update their django, they should freeze version in requirements.txt