### PR TITLE
django 2 support: cascade delete

### DIFF
--- a/django_geoip/migrations/0001_initial.py
+++ b/django_geoip/migrations/0001_initial.py
@@ -42,8 +42,8 @@ class Migration(migrations.Migration):
                 ('id', models.AutoField(verbose_name='ID', serialize=False, auto_created=True, primary_key=True)),
                 ('start_ip', models.BigIntegerField(verbose_name='Ip range block beginning, as integer', db_index=True)),
                 ('end_ip', models.BigIntegerField(verbose_name='Ip range block ending, as integer', db_index=True)),
-                ('city', models.ForeignKey(to='django_geoip.City', null=True)),
-                ('country', models.ForeignKey(to='django_geoip.Country')),
+                ('city', models.ForeignKey(to='django_geoip.City', null=True, on_delete=models.CASCADE)),
+                ('country', models.ForeignKey(to='django_geoip.Country', on_delete=models.CASCADE)),
             ],
             options={
                 'verbose_name': 'IP range',
@@ -56,7 +56,7 @@ class Migration(migrations.Migration):
             fields=[
                 ('id', models.AutoField(verbose_name='ID', serialize=False, auto_created=True, primary_key=True)),
                 ('name', models.CharField(max_length=255, verbose_name='region name')),
-                ('country', models.ForeignKey(related_name='regions', to='django_geoip.Country')),
+                ('country', models.ForeignKey(related_name='regions', to='django_geoip.Country', on_delete=models.CASCADE)),
             ],
             options={
                 'verbose_name': 'region',
@@ -71,13 +71,13 @@ class Migration(migrations.Migration):
         migrations.AddField(
             model_name='iprange',
             name='region',
-            field=models.ForeignKey(to='django_geoip.Region', null=True),
+            field=models.ForeignKey(to='django_geoip.Region', null=True, on_delete=models.CASCADE),
             preserve_default=True,
         ),
         migrations.AddField(
             model_name='city',
             name='region',
-            field=models.ForeignKey(related_name='cities', to='django_geoip.Region'),
+            field=models.ForeignKey(related_name='cities', to='django_geoip.Region', on_delete=models.CASCADE),
             preserve_default=True,
         ),
         migrations.AlterUniqueTogether(

--- a/django_geoip/models.py
+++ b/django_geoip/models.py
@@ -6,7 +6,7 @@ from abc import ABCMeta
 from django.db import models
 from django.db.models.base import ModelBase
 from django.utils.translation import ugettext_lazy as _
-from django.utils.encoding import python_2_unicode_compatible
+from django.utils.six import python_2_unicode_compatible
 from django.db.models.query import QuerySet
 
 # keep imports

--- a/django_geoip/models.py
+++ b/django_geoip/models.py
@@ -35,7 +35,7 @@ class Region(models.Model):
         Cities belong to one specific Region.
         Identified by country and name.
     """
-    country = models.ForeignKey(Country, related_name='regions')
+    country = models.ForeignKey(Country, related_name='regions', on_delete=models.CASCADE)
     name = models.CharField(_('region name'), max_length=255)
 
     def __str__(self):
@@ -53,7 +53,7 @@ class City(models.Model):
         Identified by name and region.
         Contains additional latitude/longitude info.
     """
-    region = models.ForeignKey(Region, related_name='cities')
+    region = models.ForeignKey(Region, related_name='cities', on_delete=models.CASCADE)
     name = models.CharField(_('city name'), max_length=255)
     latitude = models.DecimalField(max_digits=9, decimal_places=6, blank=True, null=True)
     longitude = models.DecimalField(max_digits=9, decimal_places=6, blank=True, null=True)
@@ -120,9 +120,9 @@ class IpRange(models.Model):
     """
     start_ip = models.BigIntegerField(_('Ip range block beginning, as integer'), db_index=True)
     end_ip = models.BigIntegerField(_('Ip range block ending, as integer'), db_index=True)
-    country = models.ForeignKey(Country)
-    region = models.ForeignKey(Region, null=True)
-    city = models.ForeignKey(City, null=True)
+    country = models.ForeignKey(Country, on_delete=models.CASCADE)
+    region = models.ForeignKey(Region, null=True, on_delete=models.CASCADE)
+    city = models.ForeignKey(City, null=True, on_delete=models.CASCADE)
 
     objects = IpRangeManager()
 


### PR DESCRIPTION
`on_delete` will become a required argument in Django 2. In older versions it defaults to `CASCADE`.